### PR TITLE
Added cloudwatch logs for lambdas

### DIFF
--- a/infrastructure/terraform/components/notifyai/README.md
+++ b/infrastructure/terraform/components/notifyai/README.md
@@ -18,6 +18,7 @@
 | <a name="input_environment"></a> [environment](#input\_environment) | The name of the tfscaffold environment | `string` | n/a | yes |
 | <a name="input_evaluation-evaluator-model-identifier"></a> [evaluation-evaluator-model-identifier](#input\_evaluation-evaluator-model-identifier) | Full identifier of the model to use for the evaluation evaluator | `string` | n/a | yes |
 | <a name="input_evaluation-inference-model-identifier"></a> [evaluation-inference-model-identifier](#input\_evaluation-inference-model-identifier) | Full identifier of the model to use for the evaluation inferance | `string` | n/a | yes |
+| <a name="input_evaluation-schedule-days"></a> [evaluation-schedule-days](#input\_evaluation-schedule-days) | The amount of days between automated evaluations being run NOTE: Set quite high for dev envrionments, to lower costs | `string` | n/a | yes |
 | <a name="input_first-run"></a> [first-run](#input\_first-run) | Doesn't create resources that are dependant on an external stimulus the first time, i.e. App Runner won't work first time, as it needs a docker container we upload after terraform, in the Github action | `bool` | n/a | yes |
 | <a name="input_group"></a> [group](#input\_group) | The group variables are being inherited from (often synonmous with account short-name) | `string` | n/a | yes |
 | <a name="input_log_retention_in_days"></a> [log\_retention\_in\_days](#input\_log\_retention\_in\_days) | The retention period in days for the Cloudwatch Logs events to be retained, default of 0 is indefinite | `number` | `0` | no |

--- a/infrastructure/terraform/components/notifyai/cloudwatch.tf
+++ b/infrastructure/terraform/components/notifyai/cloudwatch.tf
@@ -1,0 +1,24 @@
+resource "aws_cloudwatch_log_group" "bedrock_lambda_execution" {
+  name              = "/aws/lambda/${aws_lambda_function.bedrock-messager.function_name}"
+  retention_in_days = var.log_retention_in_days
+
+  tags = merge(
+    local.default_tags,
+    {
+      Name = aws_lambda_function.bedrock-messager.function_name
+    },
+  )
+}
+
+
+resource "aws_cloudwatch_log_group" "bedrock_lambda_evaluations" {
+  name              = "/aws/lambda/${aws_lambda_function.bedrock_evaluations.function_name}"
+  retention_in_days = var.log_retention_in_days
+
+  tags = merge(
+    local.default_tags,
+    {
+      Name = aws_lambda_function.bedrock_evaluations.function_name
+    },
+  )
+}

--- a/infrastructure/terraform/components/notifyai/eventbridge.tf
+++ b/infrastructure/terraform/components/notifyai/eventbridge.tf
@@ -5,9 +5,9 @@ module "eventbridge" {
   bus_name = "${local.csi}-evaluations_bus"
 
   schedules = {
-    lambda-cron = {
+    "${local.csi}-lambda-cron" = {
       description         = "Trigger for Lambda evaluations"
-      schedule_expression = "rate(3 days)"
+      schedule_expression = "rate(${var.evaluation-schedule-days} days)"
       timezone            = "Europe/London"
       arn                 = aws_lambda_function.bedrock_evaluations.arn
       input               = jsonencode({ "job" : "cron-by-rate" })

--- a/infrastructure/terraform/components/notifyai/lambda.tf
+++ b/infrastructure/terraform/components/notifyai/lambda.tf
@@ -51,7 +51,10 @@ data "aws_iam_policy_document" "bedrock_access" {
       "bedrock:ApplyGuardrail",
       "bedrock:CreateEvaluationJob",
       "bedrock:DescribeEvaluationJob",
-      "bedrock:GetEvaluationJob"
+      "bedrock:GetEvaluationJob",
+      "logs:CreateLogGroup",
+      "logs:CreateLogStream",
+      "logs:PutLogEvents"
     ]
     resources = [
       "arn:aws:bedrock:${var.region}::foundation-model/*",
@@ -63,7 +66,8 @@ data "aws_iam_policy_document" "bedrock_access" {
       "${aws_s3_bucket.lambda_prompt_logging_s3_bucket.arn}/${local.s3_lambda_logging_key}*",
       "arn:aws:bedrock:${var.region}:${var.aws_account_id}:guardrail/*",
       "arn:aws:bedrock:${var.region}:${var.aws_account_id}:inference-profile/eu.amazon.nova-pro-v1:*",
-      "arn:aws:bedrock:${var.region}::foundation-model/amazon.nova-pro-v1:0"
+      "arn:aws:bedrock:${var.region}::foundation-model/amazon.nova-pro-v1:0",
+      "arn:aws:logs:${var.region}:${var.aws_account_id}:log-group:/aws/lambda/${local.lambda_name}:*"
     ]
   }
 }

--- a/infrastructure/terraform/components/notifyai/variables.tf
+++ b/infrastructure/terraform/components/notifyai/variables.tf
@@ -99,3 +99,8 @@ variable "evaluation-inference-model-identifier" {
   type        = string
   description = "Full identifier of the model to use for the evaluation inferance"
 }
+
+variable "evaluation-schedule-days" {
+  type        = string
+  description = "The amount of days between automated evaluations being run NOTE: Set quite high for dev envrionments, to lower costs"
+}

--- a/infrastructure/terraform/etc/env_eu-west-2_dev1.tfvars
+++ b/infrastructure/terraform/etc/env_eu-west-2_dev1.tfvars
@@ -8,3 +8,6 @@ prompt-top-p                = 0.5
 prompt-model                          = "amazon.nova-pro-v1:0"
 evaluation-evaluator-model-identifier = "amazon.nova-pro-v1:0"
 evaluation-inference-model-identifier = "amazon.nova-pro-v1:0"
+evaluation-schedule-days              = 30
+
+log_retention_in_days = 3

--- a/infrastructure/terraform/etc/env_eu-west-2_dev2.tfvars
+++ b/infrastructure/terraform/etc/env_eu-west-2_dev2.tfvars
@@ -8,3 +8,6 @@ prompt-top-p                = 0.5
 prompt-model                          = "amazon.nova-pro-v1:0"
 evaluation-evaluator-model-identifier = "amazon.nova-pro-v1:0"
 evaluation-inference-model-identifier = "amazon.nova-pro-v1:0"
+evaluation-schedule-days              = 30
+
+log_retention_in_days = 3

--- a/infrastructure/terraform/etc/env_eu-west-2_test.tfvars
+++ b/infrastructure/terraform/etc/env_eu-west-2_test.tfvars
@@ -8,3 +8,4 @@ prompt-top-p                = 0.5
 prompt-model                          = "amazon.nova-pro-v1:0"
 evaluation-evaluator-model-identifier = "amazon.nova-pro-v1:0"
 evaluation-inference-model-identifier = "amazon.nova-pro-v1:0"
+evaluation-schedule-days              = 3

--- a/src/frontend/notifai-uploader/public/index.html
+++ b/src/frontend/notifai-uploader/public/index.html
@@ -24,7 +24,7 @@
       work correctly both with client-side routing and a non-root public URL.
       Learn how to configure a non-root public URL by running `npm run build`.
     -->
-    <title>Notif-AI Document Assessor</title>
+    <title>Notify AI Document Assessor</title>
   </head>
   <body>
     <script src="%PUBLIC_URL%/env-config.js"></script>

--- a/src/frontend/notifai-uploader/src/components/Header.js
+++ b/src/frontend/notifai-uploader/src/components/Header.js
@@ -10,7 +10,7 @@ export default function Header() {
     <header className="nhsuk-header" style={{ backgroundColor: '#005eb8', padding: '10px 20px' }}>
         <div className="nhsuk-header__logo-title" style={{ display: 'flex', alignItems: 'center', justifyContent: 'flex-start' }}>
           <img src={window.env?.PUBLIC_URL || process.env.PUBLIC_URL + '/nhs-england-white.svg'} alt="NHS logo" className="nhsuk-header-logo" style={{ height: '80px', marginRight: '10px' }} />
-          <h1 style={{ margin: 0, color: '#ffffff', fontSize: '24px' }}>Notif-AI</h1>
+          <h1 style={{ margin: 0, color: '#ffffff', fontSize: '24px' }}>Notify AI</h1>
         </div>
         <div style={{ height: '100%', width: '2px', backgroundColor: '#ffffff', margin: '0 20px' }}></div>
         <div className="nhsuk-width-container" style={{ display: 'flex', alignItems: 'center', justifyContent: 'center', position: 'absolute', width: '100%' }}>


### PR DESCRIPTION
<!-- markdownlint-disable-next-line first-line-heading -->

- Lambda's now have log groups assigned. FYI didn't amend logging for App Runners, as they already have default logging, and this is sufficient for now
- Updated the time period for Evaluation runs to be config driven, and updated Dev enviro's to only run once every 30 days, to save on cost
- Updated log retention on dev enviro's to only be 3 days, to save on cost. Other enviro's are the default of 10
- Updated Notify AI name to be consistent across the site

<!-- Describe your changes in detail. -->

## Context

<!-- Why is this change required? What problem does it solve? -->

## Type of changes

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [x] Refactoring (non-breaking change)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I am familiar with the [contributing guidelines](../docs/CONTRIBUTING.md)
- [x] I have followed the code style of the project
- [ ] I have added tests to cover my changes
- [ ] I have updated the documentation accordingly
- [ ] This PR is a result of pair or mob programming

---

## Sensitive Information Declaration

To ensure the utmost confidentiality and protect your and others privacy, we kindly ask you to NOT including [PII (Personal Identifiable Information) / PID (Personal Identifiable Data)](https://digital.nhs.uk/data-and-information/keeping-data-safe-and-benefitting-the-public) or any other sensitive data in this PR (Pull Request) and the codebase changes. We will remove any PR that do contain any sensitive information. We really appreciate your cooperation in this matter.

- [ ] I confirm that neither PII/PID nor sensitive data are included in this PR and the codebase changes.
