### PR TITLE
Added ExpectedBucketOwner

### DIFF
--- a/infrastructure/terraform/components/notifyai/lambda.tf
+++ b/infrastructure/terraform/components/notifyai/lambda.tf
@@ -108,6 +108,7 @@ resource "aws_lambda_function" "bedrock-messager" {
       env_logging_s3_key_prefix = local.s3_lambda_logging_key
       env_guardrail_arn         = aws_bedrock_guardrail.notifai-bedrock-guardrail.guardrail_arn
       env_guardrail_version     = "DRAFT"
+      env_logging_s3_account_id = var.aws_account_id
     }
   }
 }

--- a/src/backend/bedrock-prompt-messager/core/config.py
+++ b/src/backend/bedrock-prompt-messager/core/config.py
@@ -12,3 +12,4 @@ class BedrockConfig:
         self.logging_s3_key_prefix = os.environ.get("env_logging_s3_key_prefix")
         self.guardrail = os.environ.get("env_guardrail_arn")
         self.guardrail_version = os.environ.get("env_guardrail_version")
+        self.logging_s3_account_id = os.environ.get("env_logging_s3_account_id")

--- a/src/backend/bedrock-prompt-messager/services/bedrock_service.py
+++ b/src/backend/bedrock-prompt-messager/services/bedrock_service.py
@@ -135,7 +135,7 @@ class BedrockService:
     def log_prompt_details_to_s3(
         self, promptinput, promptoutput, guardrail_assessment, filename
     ):
-        if not self.config.logging_s3_bucket or not self.config.logging_s3_key_prefix:
+        if not self.config.logging_s3_bucket or not self.config.logging_s3_key_prefix or not self.config.logging_s3_account_id:
             print(constants.ERROR_S3_LOGGING_NOT_CONFIGURED)
             return
 
@@ -164,6 +164,7 @@ class BedrockService:
                 Key=s3_key,
                 Body=json.dumps(log_data, indent=4),
                 ContentType="application/json",
+                ExpectedBucketOwner=self.config.logging_s3_account_id,
             )
         except Exception as e:
             print(f"Error logging to S3: {e}")

--- a/src/backend/bedrock-prompt-messager/tests/conftest.py
+++ b/src/backend/bedrock-prompt-messager/tests/conftest.py
@@ -12,3 +12,4 @@ def set_env_vars(monkeypatch):
     monkeypatch.setenv("env_logging_s3_key_prefix", "logs/")
     monkeypatch.setenv("env_guardrail_arn", "test-arn")
     monkeypatch.setenv("env_guardrail_version", "1")
+    monkeypatch.setenv("env_logging_s3_account_id", "123456789012")


### PR DESCRIPTION
<!-- markdownlint-disable-next-line first-line-heading -->
## Description

Added ExpectedBucketOwner parameter to S3 put operation

## Context

This addresses an Issue raised by Sonar cloud 

S3 operations should verify bucket ownership using ExpectedBucketOwner parameter [python:S7608](https://sonarcloud.io/organizations/nhsdigital/rules?open=python%3AS7608&rule_key=python%3AS7608)

## Type of changes

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [] Refactoring (non-breaking change)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I am familiar with the [contributing guidelines](../docs/CONTRIBUTING.md)
- [ ] I have followed the code style of the project
- [ ] I have added tests to cover my changes
- [ ] I have updated the documentation accordingly
- [ ] This PR is a result of pair or mob programming

---

## Sensitive Information Declaration

To ensure the utmost confidentiality and protect your and others privacy, we kindly ask you to NOT including [PII (Personal Identifiable Information) / PID (Personal Identifiable Data)](https://digital.nhs.uk/data-and-information/keeping-data-safe-and-benefitting-the-public) or any other sensitive data in this PR (Pull Request) and the codebase changes. We will remove any PR that do contain any sensitive information. We really appreciate your cooperation in this matter.

- [ ] I confirm that neither PII/PID nor sensitive data are included in this PR and the codebase changes.
